### PR TITLE
update dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val versions = new {
-  val outwatch = "1.0.0-RC4"
-  val colibri  = "0.1.2"
-  val funStack = "0.1.4"
+  val outwatch = "1.0.0-RC5"
+  val colibri  = "0.2.2"
+  val funStack = "0.1.6"
   val tapir    = "0.19.0"
   val funPack  = "0.1.4"
 }

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -4,9 +4,9 @@ ThisBuild / version      := "0.1.0-SNAPSHOT"
 ThisBuild / scalaVersion := "2.13.7"
 
 val versions = new {
-  val outwatch = "1.0.0-RC4"
-  val colibri  = "0.1.2"
-  val funStack = "0.1.4"
+  val outwatch = "1.0.0-RC5"
+  val colibri  = "0.2.2"
+  val funStack = "0.1.6"
   val tapir    = "0.19.0"
   val funPack  = "0.1.4"
 }


### PR DESCRIPTION
- ScalablyTyped 1.0.0-beta37 (#16)
- Update scalafmt-core to 3.3.1 (#18)
- fix readme
- Fix outwatch snabbdom workaround (#20)
- Aggregate scalaStewardUpdater in root project
- Outwatch 1.0.0-RC5, colibri 0.2.2, funstack 0.1.6
